### PR TITLE
modify now dispatches between modifyHtml and modifyBlob

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ build:
 
 .PHONY:	test
 test:
-	nodejs 'make-static.js' 'https://example.net'
+	nodejs 'make-static.js' 'https://violetland.github.io/'
 

--- a/src/Path.js
+++ b/src/Path.js
@@ -125,10 +125,11 @@ module.exports = function(_base) {
 	
 	/**
 	 * @param {URI} uri Document's location
+	 * @param {string} contentType Document's content type
 	 * @return {string or false} Relative path to document if below base
 	 *     otherwise false
 	 */
-	return function(uri) {
+	return function(uri, contentType) {
 		
 		if (!(uri instanceof URI)) {
 			throw new Error('Argument must be an instance of URI but is `'+ uri +'\'');
@@ -159,7 +160,7 @@ module.exports = function(_base) {
 		
 		/* Append HTML file extension
 		 */
-		if (!/\.html?$/.test(path)) {
+		if (('text/html' === contentType) && !/\.html?$/.test(path)) {
 			path += '.html';
 		}
 		


### PR DESCRIPTION
Depending on a document's content type, `modify` now dispatches between `modifyHtml` and `modifyBlob`.

In the future this could be extended to support more content types like stylesheets and JavaScript.