### PR TITLE
Use absolute links in HTML

### DIFF
--- a/src/ReferencedDocuments.js
+++ b/src/ReferencedDocuments.js
@@ -84,8 +84,12 @@ module.exports = function(_base, _document, _path) {
 
 			/* Change reference to local file (will most likely be a
 			 * relative path)
+			 *
+			 * @warning It's easier to make all references absolute
+			 *     otherwise we would have to change the documents'
+			 *     base URL
 			 */
-			var path = _path(absolute);
+			var path = '/' + _path(absolute);
 
 
 			/* Keep anchor for JavaScript actions


### PR DESCRIPTION
Otherwise the HTML document's base URL must be modified. Using absolute URLs means the export cannot be moved into a subdirectory without additional changes, but this is sufficient for now.