### PR TITLE
Fix maximum recursion issue when downloading many documents

### DIFF
--- a/make-static.js
+++ b/make-static.js
@@ -73,7 +73,7 @@ tmp.dir({prefix: 'make-static-'}, function(err, directory) {
 		new Path(base),
 		directory
 	);
-	var limit = 1;
+	var limit = 10;
 
 
 	/* Get progress notifications
@@ -91,7 +91,6 @@ tmp.dir({prefix: 'make-static-'}, function(err, directory) {
 		/* Add all files and directories to archive and remove temporary
 		 * files afterwards
 		 */
-		var level = 9;
 		var name = base.hostname() +'.tar.gz';
 
 		tar.create({

--- a/src/MakeStatic.js
+++ b/src/MakeStatic.js
@@ -190,10 +190,12 @@ module.exports = function(_base, _asset, _path, _directory) {
 	 * @param {function} before Should be invoked before `next'
 	 */
 	var invoke_next = function(before) {
-		try {
-			before();
-		} finally {
-			next();
-		}
+		process.nextTick(function() {
+			try {
+				before();
+			} finally {
+				next();
+			}
+		});
 	};
 };


### PR DESCRIPTION
By yielding to `process.nextTick` we ensure to clean our stack.