### PR TITLE
Support for CSS documents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -492,6 +492,11 @@
 				"tweetnacl": "~0.14.0"
 			}
 		},
+		"string-replace-async": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/string-replace-async/-/string-replace-async-2.0.0.tgz",
+			"integrity": "sha512-AHMupZscUiDh07F1QziX7PLoB1DQ/pzu19vc8Xa8LwZcgnOXaw7yCgBuSYrxVEfaM2d8scc3Gtp+i+QJZV+spw=="
+		},
 		"string_decoder": {
 			"version": "0.10.31",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"mkdirp": "0.3.5",
 		"optimist": "0.6.0",
 		"request": "2.88.2",
+		"string-replace-async": "2.0.0",
 		"tar": "6.1.12",
 		"tmp": "0.0.23",
 		"trace-error": "1.0.3",

--- a/src/Document.js
+++ b/src/Document.js
@@ -27,6 +27,7 @@ var fs = require('fs');
 var mkdirp = require('mkdirp');
 var path = require('path');
 var request = require('request');
+var stringReplaceAsync = require('string-replace-async');
 var URI = require('urijs');
 
 var ReferencedAssets = require('./ReferencedAssets.js');
@@ -90,6 +91,110 @@ module.exports = function(_base, _asset, _path, _directory) {
 
 
 	/**
+	 * Will not perform any modifications on binary documents.
+	 *
+	 * @param {URI} uri Document's location
+	 * @param {http.ServerResponse} response The document already
+	 *     downloaded from the server
+	 * @param {callback} cb Should point to save
+	 */
+	var modifyBlob = function(uri, response, cb) {
+		const contentType = response.headers['content-type'] ? response.headers['content-type'] : 'application/octet-stream';
+		cb(null, uri, contentType, response.body, []);
+	};
+
+
+
+	/**
+	 * Will resolve references to assets
+	 *
+	 * @param {URI} uri Document's location
+	 * @param {http.ServerResponse} response The document already
+	 *     downloaded from the server
+	 * @param {callback} cb Should point to save
+	 */
+	var modifyCss = function(uri, response, cb) {
+		const originalStylesheet = response.body;
+
+		/* @warning RegExp does not propperly support quoted URLs, but
+		 *     should be fine as long as there are no parenthesis inside
+		 *     the URL
+		 */
+		stringReplaceAsync(originalStylesheet, /url\s*\(([^)]+)\)/g, function(match, url) {
+
+			/* {@code url} might still contain quotes
+			 */
+			url = url.trim();
+
+			if (('\'' === url[0]) && ('\'' === url[url.length - 1])) {
+				url = url.substring(1, url.length - 1);
+			} else if (('"' === url[0]) && ('"' === url[url.length - 1])) {
+				url = url.substring(1, url.length - 1);
+			}
+
+
+			/* Resolve absolute URL from maybe relative URL
+			 */
+			var relative = new URI(url);
+
+			let absolute = null;
+			try {
+				absolute = relative.absoluteTo(uri);
+			} catch (e) {
+				return new Promise(function(resolve) {
+					resolve('url(\'' + url + '\')');
+				});
+			}
+
+
+			/* Download asset and return asset's URL
+			 */
+			return new Promise(function(resolve, reject) {
+
+				/* Don't fiddle with the URI if it's not below base
+				 */
+				var base_s = _base.toString();
+				var absolute_s = absolute.toString();
+
+				if (0 !== absolute_s.indexOf(base_s)) {
+					resolve('url(\'' + url + '\')');
+					return;
+				}
+
+				_asset(absolute, function(err, absolute_asset_path) {
+
+					/* We do not want to reject the promise
+					 * just because a referenced asset
+					 * inside a stylesheet could not be
+					 * downloaded
+					 */
+					if (err) {
+						resolve('url(\'' + url + '\')');
+						return;
+					}
+
+					var absolute_document_path = path.resolve(
+						_directory, _path(uri)
+					);
+					var relative_asset_path = path.relative(
+						path.dirname(absolute_document_path),
+						absolute_asset_path
+					);
+
+					resolve('url(\'' + relative_asset_path + '\')');
+				});
+			});
+
+		}).then(function(patchedStylesheet) {
+			cb(null, uri, 'text/css', patchedStylesheet, []);
+		}, function(err) {
+			cb(err);
+		});
+	};
+
+
+
+	/**
 	 * Will resolve references to assets and save references to other
 	 * documents
 	 *
@@ -109,7 +214,6 @@ module.exports = function(_base, _asset, _path, _directory) {
 		);
 		$('img[src]').each(new referenced_assets('src'));
 		$('script').each(new referenced_assets('src'));
-		$('link[rel="stylesheet"]').each(new referenced_assets('href'));
 
 
 		/* Collect document references
@@ -118,6 +222,7 @@ module.exports = function(_base, _asset, _path, _directory) {
 			_base, uri, _path
 		);
 		$('a[href]').each(new reference_document('href'));
+		$('link[rel="stylesheet"]').each(new reference_document('href'));
 
 
 		/* Download all assets
@@ -137,21 +242,6 @@ module.exports = function(_base, _asset, _path, _directory) {
 
 
 	/**
-	 * Will not perform any modifications on binary documents.
-	 *
-	 * @param {URI} uri Document's location
-	 * @param {http.ServerResponse} response The document already
-	 *     downloaded from the server
-	 * @param {callback} cb Should point to save
-	 */
-	var modifyBlob = function(uri, response, cb) {
-		const contentType = response.headers['content-type'] ? response.headers['content-type'] : 'application/octet-stream';
-		cb(null, uri, contentType, response.body, []);
-	};
-
-
-
-	/**
 	 * Will perform modifications on downloaded content depending on content
 	 * type
 	 *
@@ -162,15 +252,25 @@ module.exports = function(_base, _asset, _path, _directory) {
 	 */
 	var modify = function(uri, response, cb) {
 
-		/* If not an HTML document, use {@code modifyBlob}. Otherwise
-		 * discover further references
+		/* If not a document, use {@code modifyBlob}. Otherwise discover
+		 * further references
 		 */
-		if (!response.headers['content-type'] || !/^text\/html/i.test(response.headers['content-type']) || ('string' !== typeof(response.body))) {
+		if (!response.headers['content-type'] || ('string' !== typeof(response.body))) {
 			modifyBlob(uri, response, cb);
 			return;
 		}
 
-		modifyHtml(uri, response, cb);
+		if (/^text\/css/i.test(response.headers['content-type'])) {
+			modifyCss(uri, response, cb);
+			return;
+		}
+
+		if (/^text\/html/i.test(response.headers['content-type'])) {
+			modifyHtml(uri, response, cb);
+			return;
+		}
+
+		modifyBlob(uri, response, cb);
 	};
 
 


### PR DESCRIPTION
CSS documents are now handled like HTML documents and searched for asset references. The current implementation has a couple of drawbacks:

* Assets referenced by CSS documents are not downloaded in parallel (due to the string-replace-async library implementation)
* Everything references by CSS documents is threated as an asset, even if it's CSS itself (tricky to fix without risking infinite loops)
* Error reporting while downloading assets is underwhelming, mostley they are ignored